### PR TITLE
FER-2465: Ignore whitespace and line-ending differences in config value comparison

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md — AppConfigurationSync
+
+## Project Overview
+
+AppConfigurationSync is a .NET 8 console tool that compares two Azure App Configuration resources and highlights differences. It surfaces keys missing in the destination (red) and keys present but with differing values (green). It can also create a snapshot of the destination before syncing.
+
+## Solution Structure
+
+```
+AppConfigurationSync/
+├── AppConfigurationSync.csproj   # .NET 8 console app
+├── AppConfigurationSync.sln
+├── Program.cs                    # All logic (entry point, comparison, snapshot creation)
+└── README.md
+```
+
+## Tech Stack
+
+- **.NET 8.0** console app
+- **Azure.Data.AppConfiguration** — reads settings and creates snapshots
+- **Microsoft.Extensions.Configuration** + **UserSecrets** — connection strings kept out of source
+- **Spectre.Console** — colored output and interactive prompts
+
+## Build & Run
+
+```bash
+# Restore dependencies
+dotnet restore
+
+# Run (connection strings must be in user secrets)
+dotnet run
+
+# Build only
+dotnet build
+```
+
+## Configuration
+
+Connection strings are stored in user secrets (never commit real values):
+
+```json
+{
+  "ConnectionStrings": {
+    "SourceAppConfig": "<source-connection-string>",
+    "DestinationAppConfig": "<destination-connection-string>"
+  }
+}
+```
+
+## Key Behaviours
+
+- Labels `Development` and `Staging` are excluded from comparison.
+- Values are compared after trimming whitespace — whitespace-only differences are ignored.
+- Snapshot creation is optional; the tool prompts before creating one.
+- The tool optionally shows keys that are identical in both stores.
+
+## Branch & Commit Conventions
+
+- **Feature branches:** `craig/[ticket-id]-[short-desc]`
+- **Commit messages:** `FER-XXXX: Description`
+
+## What Not to Do
+
+- Do not commit real connection strings or secrets.
+- Do not add error handling for impossible code paths.
+- Do not skip trimming when comparing values — whitespace differences should be ignored.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md — AppConfigurationSync
+
+## Project Overview
+
+AppConfigurationSync is a .NET 8 console tool that compares two Azure App Configuration resources and highlights differences. It surfaces keys missing in the destination (red) and keys present but with differing values (green). It can also create a snapshot of the destination before syncing.
+
+## Solution Structure
+
+```
+AppConfigurationSync/
+├── AppConfigurationSync.csproj   # .NET 8 console app
+├── AppConfigurationSync.sln
+├── Program.cs                    # All logic (entry point, comparison, snapshot creation)
+└── README.md
+```
+
+## Tech Stack
+
+- **.NET 8.0** console app
+- **Azure.Data.AppConfiguration** — reads settings and creates snapshots
+- **Microsoft.Extensions.Configuration** + **UserSecrets** — connection strings kept out of source
+- **Spectre.Console** — colored output and interactive prompts
+
+## Build & Run
+
+```bash
+# Restore dependencies
+dotnet restore
+
+# Run (connection strings must be in user secrets)
+dotnet run
+
+# Build only
+dotnet build
+```
+
+## Configuration
+
+Connection strings are stored in user secrets (never commit real values):
+
+```json
+{
+  "ConnectionStrings": {
+    "SourceAppConfig": "<source-connection-string>",
+    "DestinationAppConfig": "<destination-connection-string>"
+  }
+}
+```
+
+Set via: `dotnet user-secrets set "ConnectionStrings:SourceAppConfig" "<value>"`
+
+## Key Behaviours
+
+- Labels `Development` and `Staging` are excluded from comparison.
+- Values are compared after trimming whitespace — whitespace-only differences are ignored.
+- Snapshot creation is optional; the tool prompts before creating one.
+- The tool optionally shows keys that are identical in both stores.
+
+## Branch & Commit Conventions
+
+- **Feature branches:** `craig/[ticket-id]-[short-desc]`
+- **Commit messages:** `FER-XXXX: Description`
+
+## What Not to Do
+
+- Do not commit real connection strings or secrets.
+- Do not add error handling for impossible code paths.
+- Do not skip trimming when comparing values — whitespace differences should be ignored.

--- a/Program.cs
+++ b/Program.cs
@@ -70,7 +70,7 @@ class Program
             
             var valuesMatch = destinationSettings.Any(s => s.Key == setting.Key
                 && s.Label == setting.Label
-                && s.Value == setting.Value);
+                && NormalizeValue(s.Value) == NormalizeValue(setting.Value));
 
             if (existsInDestination && valuesMatch)
             {
@@ -115,7 +115,7 @@ class Program
                 
                 var valuesMatch = destinationSettings.Any(s => s.Key == setting.Key
                     && s.Label == setting.Label
-                    && s.Value == setting.Value);
+                    && NormalizeValue(s.Value) == NormalizeValue(setting.Value));
 
                 if (!existsInDestination || !valuesMatch)
                 {
@@ -138,6 +138,9 @@ class Program
         }
     }
     
+    private static string NormalizeValue(string? value) =>
+        (value ?? string.Empty).Trim().Replace("\r\n", "\n").Replace("\r", "\n");
+
     private static bool IsJson(string input)
     {
         input = input.Trim();


### PR DESCRIPTION
## Summary

- Adds a `NormalizeValue` helper that trims leading/trailing whitespace and normalises `\r\n`/`\r` to `\n` before comparing source and destination config values
- Applies normalisation to both the diff view and the identical-keys view
- Also adds `CLAUDE.md` and `AGENTS.md` to document the project for AI-assisted development

## Why

The sync tool was surfacing keys as different when source and destination values differed only in whitespace or line endings (e.g. a trailing newline, or CRLF vs LF in a multiline value). This made the diff noisy and harder to read.

## What reviewers should know

- `NormalizeValue` is purely for comparison — displayed values are still shown as-is (unchanged)
- The `null` case is handled: `null` normalises to `""` so a `null` vs `""` difference will still be ignored (consistent with whitespace trimming intent)

Closes FER-2465